### PR TITLE
hotfix netlify redirection

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -75,6 +75,7 @@ export default {
   },
 
   generate: {
+    fallback: true,
     routes() {
       return Promise.all([
         client.getEntries({


### PR DESCRIPTION
This PR adds fallback key in generate property of nuxt_config file. This will try to fix redirection in production netlify deployment